### PR TITLE
Fix shader compilation error

### DIFF
--- a/Assets/Scripts/Core/Portal.cs
+++ b/Assets/Scripts/Core/Portal.cs
@@ -26,7 +26,7 @@ public class Portal : MonoBehaviour {
         portalCam.enabled = false;
         trackedTravellers = new List<PortalTraveller> ();
         screenMeshFilter = screen.GetComponent<MeshFilter> ();
-        screen.material.SetInt ("active", 1);
+        screen.material.SetInt ("displayMask", 1);
     }
 
     void LateUpdate () {
@@ -104,7 +104,7 @@ public class Portal : MonoBehaviour {
 
         // Hide screen so that camera can see through portal
         screen.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.ShadowsOnly;
-        linkedPortal.screen.material.SetInt ("active", 0);
+        linkedPortal.screen.material.SetInt ("displayMask", 0);
 
         for (int i = startIndex; i < recursionLimit; i++) {
             portalCam.transform.SetPositionAndRotation (renderPositions[i], renderRotations[i]);
@@ -113,7 +113,7 @@ public class Portal : MonoBehaviour {
             portalCam.Render ();
 
             if (i == startIndex) {
-                linkedPortal.screen.material.SetInt ("active", 1);
+                linkedPortal.screen.material.SetInt ("displayMask", 1);
             }
         }
 

--- a/Assets/Scripts/Core/Shaders/Portal.shader
+++ b/Assets/Scripts/Core/Shaders/Portal.shader
@@ -30,7 +30,7 @@
 
             sampler2D _MainTex;
             float4 _InactiveColour;
-            int active; // set to 1 to display texture, otherwise will draw test colour
+            int displayMask; // set to 1 to display texture, otherwise will draw test colour
             
 
             v2f vert (appdata v)
@@ -45,7 +45,7 @@
             {
                 float2 uv = i.screenPos.xy / i.screenPos.w;
                 fixed4 portalCol = tex2D(_MainTex, uv);
-                return portalCol * active + _InactiveColour * (1-active);
+                return portalCol * displayMask + _InactiveColour * (1-displayMask);
             }
             ENDCG
         }


### PR DESCRIPTION
This pull request fixes issue #1 by changing the name of the variable **active** in *Portal.shader* to **displayMask** as well as updating its name when it's referenced in the *Portal.cs* file.
